### PR TITLE
Custom reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
 ]
 dependencies = [
-    "pytest-check",
     "pytest>=7.2",
 ]
 dynamic = ["version"]

--- a/pytest_archon/failure.py
+++ b/pytest_archon/failure.py
@@ -1,0 +1,32 @@
+"""
+This code is based on pytest-check, by Bryan Okken (MIT License)
+https://github.com/okken/pytest-check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Failure:
+    rule_name: str
+    rule_comment: str
+    reason: str
+    path: tuple[str, ...]
+
+
+_failures: list[Failure] = []
+
+
+def add_failure(rule_name, rule_comment, reason, path: list[str] | None = None):
+    global _failures
+    _failures.append(Failure(rule_name, rule_comment, reason, tuple(path) if path else ()))
+
+
+def pop_failures():
+    global _failures
+    try:
+        return _failures
+    finally:
+        _failures = []

--- a/pytest_archon/plugin.py
+++ b/pytest_archon/plugin.py
@@ -1,8 +1,50 @@
-import pytest
+from itertools import groupby
+from operator import attrgetter
 
+import pytest
+from _pytest._code.code import ExceptionInfo
+
+from pytest_archon.failure import pop_failures
 from pytest_archon.rule import archrule
 
 
 @pytest.fixture(name="archrule")
 def check_fixture():
     return archrule
+
+
+from _pytest.skipping import xfailed_key
+
+
+@pytest.hookimpl(hookwrapper=True, trylast=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+
+    failures = pop_failures()
+
+    if failures and item._store[xfailed_key]:
+        report.outcome = "skipped"
+        report.wasxfail = item._store[xfailed_key].reason
+        return
+
+    longrepr = []
+    for rule_name, rule_failures in groupby(failures, attrgetter("rule_name")):
+        longrepr.append(f"FAILED Rule '{rule_name}':")
+        for reason, reason_failures in groupby(rule_failures, attrgetter("reason")):
+            longrepr.append(f"- {reason}")
+            for path in set(f.path for f in reason_failures):
+                longrepr.append(f"    from {' ↣ '.join(path)}")
+        report.longrepr = "\n".join(longrepr)
+        report.outcome = "failed"
+
+    if failures:
+        try:
+            raise AssertionError(report.longrepr)
+        except AssertionError:
+            excinfo = ExceptionInfo.from_current()
+        call.excinfo = excinfo
+
+
+class ModelViolation(AssertionError):
+    pass

--- a/pytest_archon/rule.py
+++ b/pytest_archon/rule.py
@@ -210,13 +210,6 @@ class RuleConstraints:
             )
 
 
-def _fmt_rule(name, comment, text):
-    res = f"RULE {name}: {text}"
-    if comment:
-        res += f"\n({comment})"
-    return res
-
-
 def recurse_imports(module: str, all_imports: ImportMap) -> Iterable[Sequence[str]]:
     seen = set()
 

--- a/pytest_archon/rule.py
+++ b/pytest_archon/rule.py
@@ -4,9 +4,8 @@ from fnmatch import fnmatch
 from types import ModuleType
 from typing import Iterable, Sequence
 
-from pytest_check.check_log import log_failure  # type: ignore[import]
-
 from pytest_archon.collect import ImportMap, collect_imports, walk, walk_runtime, walk_toplevel
+from pytest_archon.failure import add_failure  # type: ignore[import]
 
 
 def archrule(name: str, comment: str | None = None) -> Rule:
@@ -162,7 +161,9 @@ class RuleConstraints:
             candidates = [k for k in candidates if not fnmatch(k, ep)]
 
         if not candidates:
-            log_failure(
+            add_failure(
+                rule_name,
+                rule_comment,
                 f"NO CANDIDATES MATCHED. Match criteria: {match_criteria}, "
                 f"exclude_criteria: {exclude_criteria}",
             )
@@ -174,23 +175,18 @@ class RuleConstraints:
             import_map = {candidate: all_imports[candidate]} if only_direct_imports else all_imports
 
             for constraint in self._check_required_constraints(candidate, import_map):
-                log_failure(
-                    _fmt_rule(
-                        rule_name,
-                        rule_comment,
-                        f"module '{candidate}' is missing REQUIRED imports matching pattern /{constraint}/",
-                    ),
+                add_failure(
+                    rule_name,
+                    rule_comment,
+                    f"module '{candidate}' is missing REQUIRED imports matching pattern /{constraint}/",
                 )
 
             for constraint, path in self._check_forbidden_constraints(candidate, import_map):
-                log_failure(
-                    _fmt_rule(
-                        rule_name,
-                        rule_comment,
-                        f"module '{candidate}' has FORBIDDEN imports:\n{path[-1]} "
-                        f"(matched by /{constraint}/), "
-                        f"through modules {' ↣ '.join(path[:-1])}.",
-                    ),
+                add_failure(
+                    rule_name,
+                    rule_comment,
+                    f"module '{candidate}' has FORBIDDEN import {path[-1]} (matched by /{constraint}/) ",
+                    path,
                 )
 
     def _check_required_constraints(self, module: str, all_imports: ImportMap):

--- a/tests/test_pytest_fixture.py
+++ b/tests/test_pytest_fixture.py
@@ -23,3 +23,4 @@ def test_rule_fail(pytester):
     )
     result = pytester.runpytest()
     result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("FAILED Rule 'abc':")

--- a/tests/test_pytest_fixture.py
+++ b/tests/test_pytest_fixture.py
@@ -2,7 +2,7 @@ def test_rule_basic(archrule):
     (
         archrule("abc", "def")
         .match("*collect")
-        .should_not_import("pytest_archon.import_finder")
+        .should_not_import("pytest_archon.failure")
         .check("pytest_archon")
     )
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -123,9 +123,9 @@ def test_required_transitive_dependency_fails(create_testset, pytester):
     )
     result = pytester.runpytest()
     result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines("FAILED Rule 'rule exclusion':")
     result.stdout.fnmatch_lines(
-        "FAILURE: RULE rule exclusion: module 'abcz.moduleA' is missing REQUIRED imports "
-        "matching pattern /abcz.moduleD/"
+        "- module 'abcz.moduleA' is missing REQUIRED imports matching pattern /abcz.moduleD/"
     )
 
 
@@ -140,6 +140,7 @@ def test_forbidden_transitive_dependency_fails(create_testset, pytester):
     pytester.makepyfile(
         """
         from pytest_archon.plugin import archrule
+
         import pytest_archon
 
         def test_rule_fail():
@@ -153,6 +154,7 @@ def test_forbidden_transitive_dependency_fails(create_testset, pytester):
     )
     result = pytester.runpytest()
     result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines("FAILURE: RULE rule exclusion: module 'abcz.moduleA' has FORBIDDEN imports*")
-    result.stdout.fnmatch_lines("abcz.moduleD (matched by /abcz.moduleD/)*")
-    result.stdout.fnmatch_lines("*through modules abcz.moduleA ↣ abcz.moduleB ↣ abcz.moduleC.*")
+    result.stdout.fnmatch_lines("FAILED Rule 'rule exclusion':")
+    result.stdout.fnmatch_lines("- module 'abcz.moduleA' has FORBIDDEN import*")
+    result.stdout.fnmatch_lines("*abcz.moduleD (matched by /abcz.moduleD/)*")
+    result.stdout.fnmatch_lines("*abcz.moduleA ↣ abcz.moduleB ↣ abcz.moduleC ↣ abcz.moduleD")

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,5 +1,7 @@
 import pytest_archon
 from pytest_archon import archrule
+from pytest_archon.failure import pop_failures
+from pytest_archon.plugin import format_failures
 
 
 def test_rule_basic():
@@ -53,25 +55,6 @@ def test_only_direct():
     )
 
 
-def test_rule_fail(pytester):
-    pytester.makepyfile(
-        """
-        from pytest_archon.plugin import archrule
-        import pytest_archon
-
-        def test_rule_fail():
-            (
-                archrule("abc", "def")
-                .match("*collect")
-                .should_not_import("importl*")
-                .check(pytest_archon)
-            )
-    """
-    )
-    result = pytester.runpytest()
-    result.assert_outcomes(failed=1)
-
-
 def test_transitive_dependency_succeeds(create_testset):
     create_testset(
         ("abcz/__init__.py", ""),
@@ -100,36 +83,25 @@ def test_transitive_dependency_via_may_import_succeeds(create_testset):
     )
 
 
-def test_required_transitive_dependency_fails(create_testset, pytester):
+def test_required_transitive_dependency_fails(create_testset):
     create_testset(
         ("abcz/__init__.py", ""),
         ("abcz/moduleA.py", "import abcz.moduleB"),
         ("abcz/moduleB.py", "import abcz.moduleC"),
         ("abcz/moduleC.py", ""),
     )
-    pytester.makepyfile(
-        """
-        from pytest_archon.plugin import archrule
-        import pytest_archon
+    (archrule("rule exclusion").match("abcz.moduleA").should_import("abcz.moduleD").check("abcz"))
 
-        def test_rule_fail():
-            (
-                archrule("rule exclusion")
-                .match("abcz.moduleA")
-                .should_import("abcz.moduleD")
-                .check("abcz")
-            )
-    """
-    )
-    result = pytester.runpytest()
-    result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines("FAILED Rule 'rule exclusion':")
-    result.stdout.fnmatch_lines(
-        "- module 'abcz.moduleA' is missing REQUIRED imports matching pattern /abcz.moduleD/"
-    )
+    failures = pop_failures()
+    longrepr = format_failures(failures)
+
+    assert failures
+
+    assert "FAILED Rule 'rule exclusion':" in longrepr
+    assert "- module 'abcz.moduleA' is missing REQUIRED imports matching pattern /abcz.moduleD/" in longrepr
 
 
-def test_forbidden_transitive_dependency_fails(create_testset, pytester):
+def test_forbidden_transitive_dependency_fails(create_testset):
     create_testset(
         ("abcz/__init__.py", ""),
         ("abcz/moduleA.py", "import abcz.moduleB"),
@@ -137,24 +109,14 @@ def test_forbidden_transitive_dependency_fails(create_testset, pytester):
         ("abcz/moduleC.py", "import abcz.moduleD"),
         ("abcz/moduleD.py", ""),
     )
-    pytester.makepyfile(
-        """
-        from pytest_archon.plugin import archrule
+    (archrule("rule exclusion").match("abcz.moduleA").should_not_import("abcz.moduleD").check("abcz"))
 
-        import pytest_archon
+    failures = pop_failures()
+    longrepr = format_failures(failures)
 
-        def test_rule_fail():
-            (
-                archrule("rule exclusion")
-                .match("abcz.moduleA")
-                .should_not_import("abcz.moduleD")
-                .check("abcz")
-            )
-    """
-    )
-    result = pytester.runpytest()
-    result.assert_outcomes(failed=1)
-    result.stdout.fnmatch_lines("FAILED Rule 'rule exclusion':")
-    result.stdout.fnmatch_lines("- module 'abcz.moduleA' has FORBIDDEN import*")
-    result.stdout.fnmatch_lines("*abcz.moduleD (matched by /abcz.moduleD/)*")
-    result.stdout.fnmatch_lines("*abcz.moduleA ↣ abcz.moduleB ↣ abcz.moduleC ↣ abcz.moduleD")
+    assert failures
+    assert longrepr
+    assert "FAILED Rule 'rule exclusion':" in longrepr
+    assert "- module 'abcz.moduleA' has FORBIDDEN import" in longrepr
+    assert "abcz.moduleD (matched by /abcz.moduleD/)" in longrepr
+    assert "abcz.moduleA ↣ abcz.moduleB ↣ abcz.moduleC ↣ abcz.moduleD" in longrepr


### PR DESCRIPTION
Improve error reporting.

This PR builds on #20.

Provide an easier to read report.
I think there's more room for improvement, but for the mean time, this is pretty okay.

Here's an example with an error I introduced in Gaphor:

```
$ pytest tests/test_architecture.py
====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
rootdir: /home/arjan/Development/gaphor, configfile: pyproject.toml
plugins: mock-3.10.0, hypothesis-6.61.0, archon-0.0.3.dev24+gea67dc0, check-1.3.0, py3arch-0.0.0, xdoctest-1.1.0, cov-3.0.0
collected 7 items                                                                                                                                                                                

tests/test_architecture.py .....F.                                                                                                                                                         [100%]

============================================================================================ FAILURES ============================================================================================
_____________________________________________________________________ test_modeling_languages_should_initialize_without_gtk ______________________________________________________________________
FAILED Rule 'No GTK dependency for modeling languages':
- module 'gaphor.C4Model.modelinglanguage' has FORBIDDEN import gi.repository.Gtk (matched by /gi.repository.Gtk/) 
    from gaphor.C4Model.modelinglanguage ↣ gaphor.C4Model.diagramitems ↣ gaphor.C4Model.diagramitems.database
==================================================================================== short test summary info =====================================================================================
FAILED tests/test_architecture.py::test_modeling_languages_should_initialize_without_gtk
================================================================================== 1 failed, 6 passed in 1.55s ===================================================================================
```