### PR TITLE
Fixed bug: may_import not working correctly

### DIFF
--- a/pytest_archon/collect.py
+++ b/pytest_archon/collect.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from importlib.util import find_spec
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Dict, Iterator, Set
+from typing import Callable, Dict, Iterator, Set, Iterable, Sequence
 
 from pytest_archon.core_modules import core_modules
 
@@ -232,3 +232,20 @@ def resolve_module_or_object_by_path(fqname: str) -> str:
             return fqname
     # we imported an object, return "parent"
     return parent_name
+
+
+def recurse_imports(module: str, all_imports: ImportMap) -> Iterable[Sequence[str]]:
+    seen = set()
+
+    def recurse(path):
+        mod = path[-1]
+        if mod in seen or mod not in all_imports:
+            return
+
+        seen.add(mod)
+        for imp in all_imports[mod]:
+            new_path = path + (imp,)
+            yield new_path
+            yield from recurse(new_path)
+
+    yield from recurse((module,))

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -5,6 +5,7 @@ from pytest_archon.collect import (
     path_to_module,
     resolve_module_or_object_by_path,
     resolve_module_or_object_by_spec,
+    recurse_imports,
 )
 
 
@@ -97,3 +98,10 @@ def test_resolve_module_or_object_by_spec():
 def test_resolve_module_or_object_by_path():
     res = resolve_module_or_object_by_path("fnmatch.fnmatch")
     assert res == "fnmatch"
+
+
+def test_recurse_imports():
+    all_imports = {"a": ["b", "c"], "b": ["c", "d"], "c": ["e"]}
+    res = list(recurse_imports("a", all_imports))
+
+    assert res == [("a", "b"), ("a", "b", "c"), ("a", "b", "c", "e"), ("a", "b", "d"), ("a", "c")]


### PR DESCRIPTION
I have a module with the file `flight_ticket/common/util.py`

```
import flight_ticket.app
```

and an empty `flight_ticket/app.py` file.

This rule should fail:

```
from pytest_archon import archrule

def test_rule():
    (
        archrule("common has no dependencies")
        .match("flight_ticket.common*")
        .should_not_import("flight_ticket*")
        .may_import("flight_ticket.common*")
        .check("flight_ticket")
    )
```
but doesn't. A second iteration in the `_check_forbidden_constraints` (now called `_find_forbidden_constraints`) did prevent proper exclusion of `.may_import` modules.

I also

* changed the naming form `check` to `find` (check in my opinion throws and exception and not a list of errors).
* moved the `recurse_imports` function to `collect.py` and added a test.

Closes #24 