### PR TITLE
Handle resolution of non-existing modules

### DIFF
--- a/pytest_archon/collect.py
+++ b/pytest_archon/collect.py
@@ -10,6 +10,7 @@ from importlib.util import find_spec
 from pathlib import Path
 from types import ModuleType
 from typing import Callable, Dict, Iterator, Set, Iterable, Sequence
+from logging import getLogger
 
 from pytest_archon.core_modules import core_modules
 
@@ -20,9 +21,9 @@ from pytest_archon.core_modules import core_modules
 
 
 Walker = Callable[[ast.Module], Iterator[ast.AST]]
-
-
 ImportMap = Dict[str, Set[str]]
+
+logger = getLogger(__name__)
 
 
 def collect_imports(package: str | ModuleType, walker: Walker) -> ImportMap:
@@ -113,6 +114,10 @@ def extract_imports_ast(nodes: Iterator[ast.AST], package: str, resolve=True) ->
                     try:
                         yield resolve_module_or_object_by_path(fqname)
                     except ModuleNotFoundError:
+                        logger.warning(
+                            f"Could not determine if {fqname} is a module or function."
+                            " Assuming it is a module."
+                        )
                         yield fqname
                 else:
                     yield fqname

--- a/pytest_archon/collect.py
+++ b/pytest_archon/collect.py
@@ -110,7 +110,10 @@ def extract_imports_ast(nodes: Iterator[ast.AST], package: str, resolve=True) ->
             for alias in node.names:
                 fqname = resolve_import_from(alias.name, node.module, package=package, level=node.level)
                 if resolve:
-                    yield resolve_module_or_object_by_path(fqname)
+                    try:
+                        yield resolve_module_or_object_by_path(fqname)
+                    except ModuleNotFoundError:
+                        yield fqname
                 else:
                     yield fqname
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -192,3 +192,13 @@ def test_forbidden_transitive_dependency_fails(create_testset):
     assert "- module 'abcz.moduleA' has FORBIDDEN import" in longrepr
     assert "abcz.moduleD (matched by glob pattern /abcz.moduleD/)" in longrepr
     assert "abcz.moduleA ↣ abcz.moduleB ↣ abcz.moduleC ↣ abcz.moduleD" in longrepr
+
+
+def test_resolution_non_existing_module(create_testset):
+    create_testset(
+        ("abcz/__init__.py", ""),
+        ("abcz/moduleA.py", "import abcz.moduleB"),
+        ("abcz/moduleB.py", "from i_do_not_exist import i_also_do_not_exist\nimport abcz.moduleC"),
+        ("abcz/moduleC.py", ""),
+    )
+    archrule("rule exclusion").match("abcz.moduleA").should_import("abcz.moduleC").check("abcz")


### PR DESCRIPTION
If a module does not exist and an "from ... import ..." construct is used, pytest-archon throws an exception. With this change the exceptions are muted and the full module name is returned, even if it might be a function.

closes #26 