### PR TITLE
Add `__all__` to __init__.py

### DIFF
--- a/pytest_archon/__init__.py
+++ b/pytest_archon/__init__.py
@@ -1,1 +1,3 @@
-from pytest_archon.rule import archrule  # noqa: F401
+from pytest_archon.rule import archrule
+
+__all__ = ["archrule"]


### PR DESCRIPTION
Implicitly re-export `archrule` in `__init__.py`, this is generally a good practice and some linters require that (flake8/ruff and mypy)